### PR TITLE
feat: add CodSpeed to the project

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,31 @@
+name: codspeed-benchmarks
+
+on:
+  # Run on pushes to the master branch
+  push:
+    branches:
+      - "master"
+  # Run on pull requests
+  pull_request:
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
+  workflow_dispatch:
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup rust toolchain, cache and cargo-codspeed binary
+        uses: moonrepo/setup-rust@v1
+        with:
+          cache-target: release
+          bins: cargo-codspeed
+
+      - name: Build the benchmark target(s)
+        run: cargo codspeed build -p lapce-app
+
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@v2
+        with:
+          run: cargo codspeed run -p lapce-app

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,10 +867,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "codspeed"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a104ac948e0188b921eb3fcbdd55dcf62e542df4c7ab7e660623f6288302089"
+dependencies = [
+ "colored",
+ "libc",
+ "serde_json",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722c36bdc62d9436d027256ce2627af81ac7a596dfc7d13d849d0d212448d7fe"
+dependencies = [
+ "codspeed",
+ "colored",
+ "criterion",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "com"
@@ -2963,8 +2995,8 @@ dependencies = [
  "bytemuck",
  "chrono",
  "clap",
+ "codspeed-criterion-compat",
  "config",
- "criterion",
  "crossbeam-channel",
  "directories",
  "dmg",
@@ -3008,7 +3040,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "url",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
  "zip",
 ]
 

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -97,7 +97,7 @@ all-languages = [
 ]
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = { version = "2.6.0", package = "codspeed-criterion-compat" }
 
 [[bench]]
 name    = "visual_line"


### PR DESCRIPTION
## Variance tests

```text
Found 101 runs for CodSpeedHQ/lapce (a7bd3888a9b40bab59edd54037c9940b91865412)
┌─────────────────────────────────────────────────────────────────────────────────────────┬────────────┬───────────────────┬─────────────────────┬────────────┬──────────────────┐
│                                         (index)                                         │  average   │ standardDeviation │ varianceCoefficient │   range    │ rangeCoefficient │
├─────────────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────┼─────────────────────┼────────────┼──────────────────┤
│  lapce-app/benches/visual_line.rs::benches::visual_line::last vline (all, no wrapping)  │  '3.2 µs'  │     '27.8 ns'     │       '0.9%'        │ '83.3 ns'  │      '2.6%'      │
│       lapce-app/benches/visual_line.rs::benches::visual_line::last vline (uninit)       │  '3.2 µs'  │     '27.8 ns'     │       '0.9%'        │ '83.3 ns'  │      '2.6%'      │
│ lapce-app/benches/visual_line.rs::benches::visual_line::vline of offset (all, wrapping) │ '129.5 µs' │    '140.4 ns'     │       '0.1%'        │ '805.6 ns' │      '0.6%'      │
│   lapce-app/benches/visual_line.rs::benches::visual_line::last vline (all, wrapping)    │  '3.3 ms'  │     '1.6 µs'      │       '0.0%'        │ '13.4 µs'  │      '0.4%'      │
│ lapce-app/benches/visual_line.rs::benches::visual_line::offset of vline (all, wrapping) │  '4.9 ms'  │     '1.3 µs'      │       '0.0%'        │  '5.7 µs'  │      '0.1%'      │
└─────────────────────────────────────────────────────────────────────────────────────────┴────────────┴───────────────────┴─────────────────────┴────────────┴──────────────────┘
```

Benchmarks are super stable 🧘 