### PR TITLE
chore(deps): bump pulldown-cmark from 0.10.2 to 0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "url",
- "windows-sys 0.36.1",
+ "windows-sys 0.52.0",
  "zip",
 ]
 
@@ -4068,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0530d13d87d1f549b66a3e8d0c688952abe5994e204ed62615baaf25dc029c"
+checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
 dependencies = [
  "bitflags 2.5.0",
  "getopts",

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -47,7 +47,7 @@ tracing-subscriber = { workspace = true }
 tracing-appender   = { workspace = true }
 url                = { workspace = true }
 
-pulldown-cmark = "0.10.2"
+pulldown-cmark = "0.10.3"
 Inflector      = "0.11.4"
 open           = "5.1.2"
 unicode-width  = "0.1.11"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3223](https://togithub.com/lapce/lapce/pull/3223).



The original branch is upstream/dependabot/cargo/pulldown-cmark-0.10.3