### PR TITLE
chore(deps): bump unicode-width from 0.1.11 to 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5684,9 +5684,9 @@ checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -50,7 +50,7 @@ url                = { workspace = true }
 pulldown-cmark = "0.10.2"
 Inflector      = "0.11.4"
 open           = "5.1.2"
-unicode-width  = "0.1.11"
+unicode-width  = "0.1.12"
 nucleo         = "0.5.0"
 bytemuck       = "1.15.0"
 config         = { version = "=0.13.4", default-features = false, features = ["toml"] }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3226](https://togithub.com/lapce/lapce/pull/3226).



The original branch is upstream/dependabot/cargo/unicode-width-0.1.12