### PR TITLE
chore(deps): bump bytemuck from 1.14.3 to 1.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,9 +565,9 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -3008,7 +3008,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "url",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
  "zip",
 ]
 

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -52,7 +52,7 @@ Inflector      = "0.11.4"
 open           = "5.1.2"
 unicode-width  = "0.1.11"
 nucleo         = "0.5.0"
-bytemuck       = "1.14.3"
+bytemuck       = "1.15.0"
 config         = { version = "=0.13.4", default-features = false, features = ["toml"] }
 structdesc     = { git = "https://github.com/lapce/structdesc" }
 base64         = "0.21.7"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3187](https://togithub.com/lapce/lapce/pull/3187).



The original branch is upstream/dependabot/cargo/bytemuck-1.15.0