### PR TITLE
chore(deps): bump chrono from 0.4.34 to 0.4.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,9 +738,9 @@ checksum = "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3165](https://togithub.com/lapce/lapce/pull/3165).



The original branch is upstream/dependabot/cargo/chrono-0.4.38