### PR TITLE
chore(deps): bump flate2 from 1.0.28 to 1.0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3245](https://togithub.com/lapce/lapce/pull/3245).



The original branch is upstream/dependabot/cargo/flate2-1.0.30