### PR TITLE
chore(deps): bump polling from 3.6.0 to 3.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "url",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
  "zip",
 ]
 
@@ -3976,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
+checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
 dependencies = [
  "cfg-if",
  "concurrent-queue",

--- a/lapce-proxy/Cargo.toml
+++ b/lapce-proxy/Cargo.toml
@@ -47,7 +47,7 @@ dyn-clone     = "1.0.16"
 walkdir       = "2.4.0"
 locale_config = "0.3.0"
 jsonrpc-lite  = "0.6.0"
-polling       = "3.5.0"
+polling       = "3.7.0"
 libc          = "0.2"
 
 # git


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3247](https://togithub.com/lapce/lapce/pull/3247).



The original branch is upstream/dependabot/cargo/polling-3.7.0