### PR TITLE
chore(deps): bump parking_lot from 0.12.1 to 0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3836,9 +3836,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ interprocess      = { version = "1.2.1" }
 itertools         = { version = "0.12.1" }
 notify            = { version = "5.2.0", features = ["serde"] }
 once_cell         = { version = "1.19" }
-parking_lot       = { version = "0.12.0" }
+parking_lot       = { version = "0.12.2" }
 rayon             = { version = "1.10.0" }
 regex             = { version = "1.10.4" }
 reqwest           = { version = "0.11", features = ["blocking", "json", "socks"] }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3263](https://togithub.com/lapce/lapce/pull/3263).



The original branch is upstream/dependabot/cargo/parking_lot-0.12.2