### PR TITLE
chore(deps): bump libc from 0.2.153 to 0.2.154

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,9 +3149,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libgit2-sys"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3269](https://togithub.com/lapce/lapce/pull/3269).



The original branch is upstream/dependabot/cargo/libc-0.2.154