### PR TITLE
chore(deps): bump bytemuck from 1.15.0 to 1.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,9 +565,9 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 dependencies = [
  "bytemuck_derive",
 ]

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -52,7 +52,7 @@ Inflector      = "0.11.4"
 open           = "5.1.2"
 unicode-width  = "0.1.12"
 nucleo         = "0.5.0"
-bytemuck       = "1.15.0"
+bytemuck       = "1.16.0"
 config         = { version = "=0.13.4", default-features = false, features = ["toml"] }
 structdesc     = { git = "https://github.com/lapce/structdesc" }
 base64         = "0.21.7"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3268](https://togithub.com/lapce/lapce/pull/3268).



The original branch is upstream/dependabot/cargo/bytemuck-1.16.0