### PR TITLE
chore(deps): bump serde_json from 1.0.107 to 1.0.117

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4603,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3265](https://togithub.com/lapce/lapce/pull/3265).



The original branch is upstream/dependabot/cargo/serde_json-1.0.117