### PR TITLE
chore(deps): bump pulldown-cmark from 0.10.3 to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
+checksum = "8746739f11d39ce5ad5c2520a9b75285310dbfe78c541ccf832d38615765aec0"
 dependencies = [
  "bitflags 2.5.0",
  "getopts",
@@ -4092,9 +4092,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-escape"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d8f9aa0e3cbcfaf8bf00300004ee3b72f74770f9cbac93f6928771f613276b"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quick-xml"

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -47,7 +47,7 @@ tracing-subscriber = { workspace = true }
 tracing-appender   = { workspace = true }
 url                = { workspace = true }
 
-pulldown-cmark   = "0.10.3"
+pulldown-cmark   = "0.11.0"
 Inflector        = "0.11.4"
 open             = "5.1.2"
 unicode-width    = "0.1.12"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3276](https://togithub.com/lapce/lapce/pull/3276).



The original branch is upstream/dependabot/cargo/pulldown-cmark-0.11.0