### PR TITLE
chore(deps): bump crossbeam-channel from 0.5.12 to 0.5.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2971,7 +2971,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "url",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ anyhow            = { version = "1.0" }
 backtrace         = { version = "0.3" }
 chrono            = { version = "0.4" }
 clap              = { version = "4.5.0", default-features = false, features = ["std", "help", "usage", "derive"] }
-crossbeam-channel = { version = "0.5.12" }
+crossbeam-channel = { version = "0.5.13" }
 directories       = { version = "4.0.1" }
 flate2            = { version = "1.0" }
 globset           = { version = "0.4.14" }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3302](https://togithub.com/lapce/lapce/pull/3302).



The original branch is upstream/dependabot/cargo/crossbeam-channel-0.5.13