### PR TITLE
chore(deps): bump open from 5.1.2 to 5.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,7 +2971,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "url",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
  "zip",
 ]
 
@@ -3633,9 +3633,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "open"
-version = "5.1.2"
+version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449f0ff855d85ddbf1edd5b646d65249ead3f5e422aaa86b7d2d0b049b103e32"
+checksum = "2eb49fbd5616580e9974662cb96a3463da4476e649a7e4b258df0de065db0657"
 dependencies = [
  "is-wsl",
  "libc",

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -48,7 +48,7 @@ url                = { workspace = true }
 
 pulldown-cmark   = { version = "0.11.0" }
 Inflector        = { version = "0.11.4" }
-open             = { version = "5.1.2" }
+open             = { version = "5.1.3" }
 unicode-width    = { version = "0.1.12" }
 nucleo           = { version = "0.5.0" }
 bytemuck         = { version = "1.15.0" }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3301](https://togithub.com/lapce/lapce/pull/3301).



The original branch is upstream/dependabot/cargo/open-5.1.3