### PR TITLE
chore(deps): bump polling from 3.6.0 to 3.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,7 +2971,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "url",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
  "zip",
 ]
 
@@ -3905,9 +3905,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.6.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
+checksum = "5e6a007746f34ed64099e88783b0ae369eaa3da6392868ba262e2af9b8fbaea1"
 dependencies = [
  "cfg-if",
  "concurrent-queue",

--- a/lapce-proxy/Cargo.toml
+++ b/lapce-proxy/Cargo.toml
@@ -43,7 +43,7 @@ dyn-clone     = "1.0.16"
 walkdir       = "2.4.0"
 locale_config = "0.3.0"
 jsonrpc-lite  = "0.6.0"
-polling       = "3.5.0"
+polling       = "3.7.1"
 libc          = "0.2"
 
 # git


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3300](https://togithub.com/lapce/lapce/pull/3300).



The original branch is upstream/dependabot/cargo/polling-3.7.1