### PR TITLE
chore(deps): bump structdesc from `47d8201` to `bb56969`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4847,7 +4847,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "structdesc"
 version = "0.1.0"
-source = "git+https://github.com/lapce/structdesc#47d8201fb13240166f4d842c718d63c1e24f0236"
+source = "git+https://github.com/lapce/structdesc#bb56969f22fdb2c2d6c03f158fd4a2bdc983b659"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3298](https://togithub.com/lapce/lapce/pull/3298).



The original branch is upstream/dependabot/cargo/structdesc-bb56969