### PR TITLE
Make editor tab separator height configurable

### DIFF
--- a/defaults/settings.toml
+++ b/defaults/settings.toml
@@ -88,6 +88,7 @@ icon-size = 0
 header-height = 36
 status-height = 25
 tab-min-width = 100
+tab-separator-height = "Content"
 scroll-width = 10
 drop-shadow-width = 0
 palette-width = 500

--- a/lapce-app/src/app.rs
+++ b/lapce-app/src/app.rs
@@ -69,7 +69,8 @@ use crate::{
         WindowCommand,
     },
     config::{
-        color::LapceColor, icon::LapceIcons, watcher::ConfigWatcher, LapceConfig,
+        color::LapceColor, icon::LapceIcons, ui::TabSeparatorHeight,
+        watcher::ConfigWatcher, LapceConfig,
     },
     db::LapceDb,
     debug::RunDebugMode,
@@ -730,7 +731,6 @@ fn editor_tab_header(
             .style(move |s| {
                 s.items_center()
                     .justify_center()
-                    .height_full()
                     .border_left(if i.get() == 0 { 1.0 } else { 0.0 })
                     .border_right(1.0)
                     .border_color(config.get().color(LapceColor::LAPCE_BORDER))
@@ -738,6 +738,11 @@ fn editor_tab_header(
                     .gap(6.)
                     .grid()
                     .grid_template_columns(vec![auto(), fr(1.), auto()])
+                    .apply_if(
+                        config.get().ui.tab_separator_height
+                            == TabSeparatorHeight::Full,
+                        |s| s.height_full(),
+                    )
             })
         };
 
@@ -842,7 +847,7 @@ fn editor_tab_header(
                         )
                         .border_color(config.color(LapceColor::LAPCE_BORDER))
                 })
-                .style(|s| s.align_items(Some(AlignItems::Center)).height_full()),
+                .style(|s| s.align_items(Some(AlignItems::Center))),
             empty()
                 .style(move |s| {
                     s.size_full()
@@ -894,7 +899,7 @@ fn editor_tab_header(
         .on_resize(move |rect| {
             layout_rect.set(rect);
         })
-        .style(|s| s.height_full())
+        .style(|s| s.height_full().flex_col().items_center().justify_center())
         .debug_name("Tab and Active Indicator")
     };
 

--- a/lapce-app/src/config.rs
+++ b/lapce-app/src/config.rs
@@ -882,6 +882,14 @@ impl LapceConfig {
                     .sorted()
                     .collect(),
             }),
+            ("ui", "tab-separator-height") => Some(DropdownInfo {
+                active_index: self.ui.tab_separator_height as usize,
+                items: ui::TabSeparatorHeight::VARIANTS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .sorted()
+                    .collect(),
+            }),
             ("terminal", "default-profile") => Some(DropdownInfo {
                 active_index: self
                     .terminal

--- a/lapce-app/src/config/ui.rs
+++ b/lapce-app/src/config/ui.rs
@@ -30,6 +30,11 @@ pub struct UIConfig {
     #[field_names(desc = "Set the minimum width for editor tab")]
     tab_min_width: usize,
 
+    #[field_names(
+        desc = "Set whether the editor tab separator should be full height or the height of the content"
+    )]
+    pub tab_separator_height: TabSeparatorHeight,
+
     #[field_names(desc = "Set the width for scroll bar")]
     scroll_width: usize,
 
@@ -77,6 +82,25 @@ pub enum TabCloseButton {
     #[default]
     Right,
     Off,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Deserialize,
+    Serialize,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    strum_macros::VariantNames,
+)]
+pub enum TabSeparatorHeight {
+    #[default]
+    Content,
+    Full,
 }
 
 impl UIConfig {


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3313](https://togithub.com/lapce/lapce/pull/3313).



The original branch is fork-3313-jrmoulton/config-sep-height