### PR TITLE
chore(deps): bump tar from 0.4.40 to 0.4.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4988,9 +4988,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3318](https://togithub.com/lapce/lapce/pull/3318).



The original branch is upstream/dependabot/cargo/tar-0.4.41