### PR TITLE
chore(deps): bump unicode-width from 0.1.12 to 0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5502,9 +5502,9 @@ checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -50,7 +50,7 @@ floem              = { workspace = true }
 pulldown-cmark   = { version = "0.11.0" }
 Inflector        = { version = "0.11.4" }
 open             = { version = "5.1.2" }
-unicode-width    = { version = "0.1.12" }
+unicode-width    = { version = "0.1.13" }
 nucleo           = { version = "0.5.0" }
 bytemuck         = { version = "1.15.0" }
 config           = { version = "=0.13.4", default-features = false, features = ["toml"] }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3317](https://togithub.com/lapce/lapce/pull/3317).



The original branch is upstream/dependabot/cargo/unicode-width-0.1.13