### PR TITLE
chore(deps): bump bytemuck from 1.15.0 to 1.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,9 +556,9 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 dependencies = [
  "bytemuck_derive",
 ]

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -52,7 +52,7 @@ Inflector        = { version = "0.11.4" }
 open             = { version = "5.1.4" }
 unicode-width    = { version = "0.1.13" }
 nucleo           = { version = "0.5.0" }
-bytemuck         = { version = "1.15.0" }
+bytemuck         = { version = "1.16.1" }
 config           = { version = "=0.13.4", default-features = false, features = ["toml"] }
 structdesc       = { git = "https://github.com/lapce/structdesc", rev = "bb56969f22fdb2c2d6c03f158fd4a2bdc983b659" }
 base64           = { version = "0.21.7" }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3350](https://togithub.com/lapce/lapce/pull/3350).



The original branch is upstream/dependabot/cargo/bytemuck-1.16.1