### PR TITLE
chore(deps): bump strum from 0.26.2 to 0.26.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4854,9 +4854,9 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ reqwest           = { version = "0.11", features = ["blocking", "json", "socks"]
 serde             = { version = "1.0" }
 serde_json        = { version = "1.0" }
 smallvec          = { version = "1.13.2" }
-strum             = { version = "0.26.2" }
+strum             = { version = "0.26.3" }
 strum_macros      = { version = "0.26.2" }
 tar               = { version = "0.4" }
 thiserror         = { version = "1.0" }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3349](https://togithub.com/lapce/lapce/pull/3349).



The original branch is upstream/dependabot/cargo/strum-0.26.3