### PR TITLE
chore(deps): bump serde_json from 1.0.117 to 1.0.120

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4522,9 +4522,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3348](https://togithub.com/lapce/lapce/pull/3348).



The original branch is upstream/dependabot/cargo/serde_json-1.0.120