### PR TITLE
chore(deps): bump open from 5.1.4 to 5.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,9 +3630,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "open"
-version = "5.1.4"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ca541f22b1c46d4bb9801014f234758ab4297e7870b904b6a8415b980a7388"
+checksum = "61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3"
 dependencies = [
  "is-wsl",
  "libc",

--- a/lapce-app/Cargo.toml
+++ b/lapce-app/Cargo.toml
@@ -50,7 +50,7 @@ floem              = { workspace = true }
 
 pulldown-cmark   = { version = "0.11.0" }
 Inflector        = { version = "0.11.4" }
-open             = { version = "5.1.4" }
+open             = { version = "5.3.0" }
 unicode-width    = { version = "0.1.13" }
 nucleo           = { version = "0.5.0" }
 bytemuck         = { version = "1.15.0" }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3365](https://togithub.com/lapce/lapce/pull/3365).



The original branch is upstream/dependabot/cargo/open-5.3.0