### PR TITLE
chore(deps): bump semver from 1.0.20 to 1.0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4496,9 +4496,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3372](https://togithub.com/lapce/lapce/pull/3372).



The original branch is upstream/dependabot/cargo/semver-1.0.23