### PR TITLE
support rust-analyzer's notification "experimental/serverStatus".

### DIFF
--- a/lapce-app/src/doc.rs
+++ b/lapce-app/src/doc.rs
@@ -799,7 +799,7 @@ impl Doc {
     }
 
     /// Request semantic styles for the buffer from the LSP through the proxy.
-    fn get_semantic_styles(&self) {
+    pub fn get_semantic_styles(&self) {
         if !self.loaded() {
             return;
         }

--- a/lapce-app/src/window_tab.rs
+++ b/lapce-app/src/window_tab.rs
@@ -1912,6 +1912,16 @@ impl WindowTabData {
                     doc.init_diagnostics();
                 }
             }
+            CoreNotification::ServerStatus { params } => {
+                if params.is_ok() {
+                    // todo filter by language
+                    self.main_split.docs.with_untracked(|x| {
+                        for doc in x.values() {
+                            doc.get_semantic_styles();
+                        }
+                    });
+                }
+            }
             CoreNotification::TerminalProcessStopped { term_id } => {
                 let _ = self
                     .common

--- a/lapce-proxy/src/plugin/mod.rs
+++ b/lapce-proxy/src/plugin/mod.rs
@@ -68,7 +68,7 @@ use lsp_types::{
 };
 use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use tar::Archive;
 use tracing::error;
 
@@ -1472,6 +1472,9 @@ pub fn remove_volt(
 }
 
 fn client_capabilities() -> ClientCapabilities {
+    // https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#server-status
+    let mut experimental = Map::new();
+    experimental.insert("serverStatusNotification".into(), true.into());
     ClientCapabilities {
         text_document: Some(TextDocumentClientCapabilities {
             synchronization: Some(TextDocumentSyncClientCapabilities {
@@ -1575,6 +1578,7 @@ fn client_capabilities() -> ClientCapabilities {
             workspace_folders: Some(true),
             ..Default::default()
         }),
+        experimental: Some(experimental.into()),
         ..Default::default()
     }
 }

--- a/lapce-proxy/src/plugin/psp.rs
+++ b/lapce-proxy/src/plugin/psp.rs
@@ -15,6 +15,7 @@ use dyn_clone::DynClone;
 use floem_editor_core::buffer::rope_text::{RopeText, RopeTextRef};
 use jsonrpc_lite::{Id, JsonRpc, Params};
 use lapce_core::{encoding::offset_utf16_to_utf8, rope_text_pos::RopeTextPosition};
+use lapce_rpc::core::ServerStatusParams;
 use lapce_rpc::{
     core::CoreRpcHandler,
     plugin::{PluginId, VoltID},
@@ -1074,6 +1075,11 @@ impl PluginHostHandler {
                         self.volt_id.author, self.volt_id.name
                     ),
                 );
+            }
+            "experimental/serverStatus" => {
+                let param: ServerStatusParams =
+                    serde_json::from_value(serde_json::to_value(params)?)?;
+                self.catalog_rpc.core_rpc.server_status(param);
             }
             _ => {
                 self.core_rpc.log(

--- a/lapce-rpc/src/core.rs
+++ b/lapce-rpc/src/core.rs
@@ -62,6 +62,9 @@ pub enum CoreNotification {
     PublishDiagnostics {
         diagnostics: PublishDiagnosticsParams,
     },
+    ServerStatus {
+        params: ServerStatusParams,
+    },
     WorkDoneProgress {
         progress: ProgressParams,
     },
@@ -302,6 +305,10 @@ impl CoreRpcHandler {
         self.notification(CoreNotification::PublishDiagnostics { diagnostics });
     }
 
+    pub fn server_status(&self, params: ServerStatusParams) {
+        self.notification(CoreNotification::ServerStatus { params });
+    }
+
     pub fn work_done_progress(&self, progress: ProgressParams) {
         self.notification(CoreNotification::WorkDoneProgress { progress });
     }
@@ -383,4 +390,17 @@ pub enum LogLevel {
     Error = 2,
     Debug = 3,
     Trace = 4,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ServerStatusParams {
+    health: String,
+    quiescent: bool,
+    message: Option<String>,
+}
+
+impl ServerStatusParams {
+    pub fn is_ok(&self) -> bool {
+        self.health.as_str() == "ok"
+    }
 }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3381](https://togithub.com/lapce/lapce/pull/3381).



The original branch is fork-3381-jm-observer/lsp_server_status