### PR TITLE
chore(deps): bump serde_json from 1.0.120 to 1.0.121

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4519,11 +4519,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3391](https://togithub.com/lapce/lapce/pull/3391).



The original branch is upstream/dependabot/cargo/serde_json-1.0.121