### PR TITLE
chore(deps): bump flate2 from 1.0.30 to 1.0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
  "miniz_oxide",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3408](https://togithub.com/lapce/lapce/pull/3408).



The original branch is upstream/dependabot/cargo/flate2-1.0.31