### PR TITLE
Add proxy and retry count to all HTTPS GET requests.

### DIFF
--- a/lapce-app/src/app/grammars.rs
+++ b/lapce-app/src/app/grammars.rs
@@ -10,11 +10,8 @@ use lapce_core::directory::Directory;
 use crate::{tracing::*, update::ReleaseInfo};
 
 fn get_github_api(url: &str) -> Result<String> {
-    let resp = reqwest::blocking::ClientBuilder::new()
-        .user_agent(format!("Lapce/{}", lapce_core::meta::VERSION))
-        .build()?
-        .get(url)
-        .send()?;
+    let user_agent = format!("Lapce/{}", lapce_core::meta::VERSION);
+    let resp = lapce_proxy::get_url(url, Some(user_agent.as_str()))?;
     if !resp.status().is_success() {
         return Err(anyhow!("get release info failed {}", resp.text()?));
     }
@@ -113,7 +110,7 @@ fn download_release(
 
     for asset in &release.assets {
         if asset.name.starts_with(file_name) {
-            let mut resp = reqwest::blocking::get(&asset.browser_download_url)?;
+            let mut resp = lapce_proxy::get_url(&asset.browser_download_url, None)?;
             if !resp.status().is_success() {
                 return Err(anyhow!("download file error {}", resp.text()?));
             }

--- a/lapce-app/src/proxy/remote.rs
+++ b/lapce-app/src/proxy/remote.rs
@@ -325,7 +325,7 @@ fn download_remote(
             };
             let url = format!("https://github.com/lapce/lapce/releases/download/{proxy_version}/{proxy_filename}.gz");
             debug!("proxy download URI: {url}");
-            let mut resp = reqwest::blocking::get(url).expect("request failed");
+            let mut resp = lapce_proxy::get_url(url, None).expect("request failed");
             if resp.status().is_success() {
                 let mut out = std::fs::File::create(&local_proxy_file)
                     .expect("failed to create file");

--- a/lapce-app/src/update.rs
+++ b/lapce-app/src/update.rs
@@ -30,11 +30,7 @@ pub fn get_latest_release() -> Result<ReleaseInfo> {
         _ => "https://api.github.com/repos/lapce/lapce/releases/latest",
     };
 
-    let resp = reqwest::blocking::ClientBuilder::new()
-        .user_agent("Lapce")
-        .build()?
-        .get(url)
-        .send()?;
+    let resp = lapce_proxy::get_url(url, Some("Lapce"))?;
     if !resp.status().is_success() {
         return Err(anyhow!("get release info failed {}", resp.text()?));
     }
@@ -76,7 +72,7 @@ pub fn download_release(release: &ReleaseInfo) -> Result<PathBuf> {
 
     for asset in &release.assets {
         if asset.name == name {
-            let mut resp = reqwest::blocking::get(&asset.browser_download_url)?;
+            let mut resp = lapce_proxy::get_url(&asset.browser_download_url, None)?;
             if !resp.status().is_success() {
                 return Err(anyhow!("download file error {}", resp.text()?));
             }

--- a/lapce-proxy/src/plugin/mod.rs
+++ b/lapce-proxy/src/plugin/mod.rs
@@ -1434,7 +1434,7 @@ pub fn download_volt(volt: &VoltInfo) -> Result<VoltMetadata> {
         volt.author, volt.name, volt.version
     );
 
-    let resp = reqwest::blocking::get(url)?;
+    let resp = crate::get_url(url, None)?;
     if !resp.status().is_success() {
         return Err(anyhow!("can't download plugin"));
     }
@@ -1442,7 +1442,7 @@ pub fn download_volt(volt: &VoltInfo) -> Result<VoltMetadata> {
     // this is the s3 url
     let url = resp.text()?;
 
-    let mut resp = reqwest::blocking::get(url)?;
+    let mut resp = crate::get_url(url, None)?;
     if !resp.status().is_success() {
         return Err(anyhow!("can't download plugin"));
     }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3413](https://togithub.com/lapce/lapce/pull/3413).



The original branch is fork-3413-jm-observer/proxy