### PR TITLE
Add error message display for plugins and LSP server.

### DIFF
--- a/lapce-proxy/src/plugin/lsp.rs
+++ b/lapce-proxy/src/plugin/lsp.rs
@@ -108,8 +108,13 @@ impl PluginServerHandler for LspClient {
         self.host.handle_request(id, method, params, resp);
     }
 
-    fn handle_host_notification(&mut self, method: String, params: Params) {
-        let _ = self.host.handle_notification(method, params);
+    fn handle_host_notification(
+        &mut self,
+        method: String,
+        params: Params,
+        from: String,
+    ) {
+        let _ = self.host.handle_notification(method, params, from);
     }
 
     fn handle_did_save_text_document(
@@ -224,6 +229,7 @@ impl LspClient {
         let local_server_rpc = server_rpc.clone();
         let core_rpc = plugin_rpc.core_rpc.clone();
         let volt_id_closure = volt_id.clone();
+        let name = volt_display_name.clone();
         thread::spawn(move || {
             let mut reader = Box::new(BufReader::new(stdout));
             loop {
@@ -232,6 +238,7 @@ impl LspClient {
                         if let Some(resp) = handle_plugin_server_message(
                             &local_server_rpc,
                             &message_str,
+                            &name,
                         ) {
                             let _ = io_tx.send(resp);
                         }

--- a/lapce-proxy/src/plugin/psp.rs
+++ b/lapce-proxy/src/plugin/psp.rs
@@ -39,7 +39,7 @@ use lsp_types::{
     },
     CodeActionProviderCapability, DidChangeTextDocumentParams,
     DidSaveTextDocumentParams, DocumentSelector, HoverProviderCapability,
-    InitializeResult, LogMessageParams, OneOf, ProgressParams,
+    InitializeResult, LogMessageParams, MessageType, OneOf, ProgressParams,
     PublishDiagnosticsParams, Range, Registration, RegistrationParams,
     SemanticTokens, SemanticTokensLegend, SemanticTokensServerCapabilities,
     ServerCapabilities, ShowMessageParams, TextDocumentContentChangeEvent,
@@ -135,6 +135,7 @@ pub enum PluginServerRpc {
     HostNotification {
         method: String,
         params: Params,
+        from: String,
     },
     DidSaveTextDocument {
         language_id: String,
@@ -210,7 +211,12 @@ pub trait PluginServerHandler {
         path: Option<&Path>,
     ) -> bool;
     fn method_registered(&mut self, method: &str) -> bool;
-    fn handle_host_notification(&mut self, method: String, params: Params);
+    fn handle_host_notification(
+        &mut self,
+        method: String,
+        params: Params,
+        from: String,
+    );
     fn handle_host_request(
         &mut self,
         id: Id,
@@ -471,8 +477,12 @@ impl PluginServerRpcHandler {
                 } => {
                     handler.handle_host_request(id, method, params, resp);
                 }
-                PluginServerRpc::HostNotification { method, params } => {
-                    handler.handle_host_notification(method, params);
+                PluginServerRpc::HostNotification {
+                    method,
+                    params,
+                    from,
+                } => {
+                    handler.handle_host_notification(method, params, from);
                 }
                 PluginServerRpc::DidSaveTextDocument {
                     language_id,
@@ -521,6 +531,7 @@ impl PluginServerRpcHandler {
 pub fn handle_plugin_server_message(
     server_rpc: &PluginServerRpcHandler,
     message: &str,
+    from: &str,
 ) -> Option<JsonRpc> {
     match JsonRpc::parse(message) {
         Ok(value @ JsonRpc::Request(_)) => {
@@ -551,6 +562,7 @@ pub fn handle_plugin_server_message(
             let rpc = PluginServerRpc::HostNotification {
                 method: value.get_method().unwrap().to_string(),
                 params: value.get_params().unwrap(),
+                from: from.to_string(),
             };
             server_rpc.handle_rpc(rpc);
             None
@@ -1019,6 +1031,7 @@ impl PluginHostHandler {
         &mut self,
         method: String,
         params: Params,
+        from: String,
     ) -> Result<()> {
         match method.as_str() {
             // TODO: remove this after the next release and once we convert all the existing plugins to use the request.
@@ -1085,6 +1098,17 @@ impl PluginHostHandler {
             "experimental/serverStatus" => {
                 let param: ServerStatusParams =
                     serde_json::from_value(serde_json::to_value(params)?)?;
+                if !param.is_ok() {
+                    if let Some(msg) = &param.message {
+                        self.core_rpc.show_message(
+                            from,
+                            ShowMessageParams {
+                                typ: MessageType::ERROR,
+                                message: msg.clone(),
+                            },
+                        );
+                    }
+                }
                 self.catalog_rpc.core_rpc.server_status(param);
             }
             _ => {

--- a/lapce-proxy/src/plugin/wasi.rs
+++ b/lapce-proxy/src/plugin/wasi.rs
@@ -123,8 +123,13 @@ impl PluginServerHandler for Plugin {
         }
     }
 
-    fn handle_host_notification(&mut self, method: String, params: Params) {
-        let _ = self.host.handle_notification(method, params);
+    fn handle_host_notification(
+        &mut self,
+        method: String,
+        params: Params,
+        from: String,
+    ) {
+        let _ = self.host.handle_notification(method, params, from);
     }
 
     fn handle_host_request(
@@ -490,9 +495,12 @@ pub fn start_volt(
 
     let local_rpc = rpc.clone();
     let local_stdin = stdin.clone();
+    let volt_name = format!("volt {}", meta.name);
     linker.func_wrap("lapce", "host_handle_rpc", move || {
         if let Ok(msg) = wasi_read_string(&stdout) {
-            if let Some(resp) = handle_plugin_server_message(&local_rpc, &msg) {
+            if let Some(resp) =
+                handle_plugin_server_message(&local_rpc, &msg, &volt_name)
+            {
                 if let Ok(msg) = serde_json::to_string(&resp) {
                     let _ = writeln!(local_stdin.write().unwrap(), "{msg}");
                 }

--- a/lapce-rpc/src/core.rs
+++ b/lapce-rpc/src/core.rs
@@ -396,7 +396,7 @@ pub enum LogLevel {
 pub struct ServerStatusParams {
     health: String,
     quiescent: bool,
-    message: Option<String>,
+    pub message: Option<String>,
 }
 
 impl ServerStatusParams {


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [lapce/lapce#3414](https://togithub.com/lapce/lapce/pull/3414).



The original branch is fork-3414-jm-observer/show-message